### PR TITLE
fix building for nix

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -6,6 +6,7 @@
   apple-sdk_11,
   extra-cmake-modules,
   gamemode,
+  ghc_filesystem,
   jdk17,
   kdePackages,
   libnbtplusplus,
@@ -77,6 +78,7 @@ stdenv.mkDerivation {
   buildInputs =
     [
       cmark
+      ghc_filesystem
       kdePackages.qtbase
       kdePackages.qtnetworkauth
       kdePackages.quazip


### PR DESCRIPTION
this pr fixes building for nix because ghc_filesystem is not removed in elyprismlauncher yet (ref. https://github.com/PrismLauncher/PrismLauncher/commit/4361aaa094820e07e9d35d96865b3851f184d49a)

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
