### PR TITLE
Allow concurrent launches of the same instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ There are already quite a few forks out in the wild that add Ely.by support and/
 - Modern and secure login: PineconeMC uses OAuth2 to log you in. This means that your credentials are never transferred to the launcher. Instead, you log into your account on the official Ely.by page in the browser, and Ely.by gives the launcher a token to access your account with limited privileges.
 - Skins support on servers: All other forks rely exclusively on authlib-injector to patch Minecraft to support Ely.by. But authlib-injector can't provide skins on servers that don't have a special skins plugin installed. PineconeMC uses Ely.by's official Authlib patches, allowing you to see skins anywhere
 
+## Multiple launches of one instance
+
+PineconeMC can run multiple independent Minecraft processes from the same instance at the same time. The **Launch** action remains available while that instance is running.
+
+- Each launch has its own lifecycle and selectable console log.
+- The instance window can stop the currently selected launch session.
+- Play time is measured as wall-clock time while at least one Minecraft process is running, so parallel sessions do not multiply it.
+- Starting another process displays a warning because all sessions share the same game directory, configuration, saves, and log files. The warning can be disabled with **Don't show this warning again**.
+
+Running multiple processes against one game directory can cause conflicting writes or data loss. Use this feature only when the selected Minecraft versions and mods can safely share those files.
+
 ## Installation
 
 - All downloads and instructions for PineconeMC can be found on the [Releases](https://github.com/ElyPrismLauncher/Launcher/releases/latest) page.

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -84,10 +84,12 @@
 #include "ApplicationMessage.h"
 
 #include <iostream>
+#include <algorithm>
 #include <mutex>
 
 #include <QAccessible>
 #include <QCommandLineParser>
+#include <QCheckBox>
 #include <QDebug>
 #include <QDir>
 #include <QFileInfo>
@@ -724,6 +726,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("AutoCloseConsole", false);
         m_settings->registerSetting("ShowConsoleOnError", true);
         m_settings->registerSetting("LogPrePostOutput", true);
+        m_settings->registerSetting("SuppressConcurrentLaunchWarning", false);
 
         // Window Size
         m_settings->registerSetting({ "LaunchMaximized", "MCWindowMaximize" }, false);
@@ -1543,6 +1546,33 @@ bool Application::launch(BaseInstance* instance,
     if (m_updateRunning) {
         qDebug() << "Cannot launch instances while an update is running. Please try again when updates are completed.";
     } else if (instance->canLaunch()) {
+        if (instance->isRunning() && !m_settings->get("SuppressConcurrentLaunchWarning").toBool()) {
+            QWidget* parent = m_mainWindow;
+            {
+                QMutexLocker locker(&m_instanceExtrasMutex);
+                const auto iter = m_instanceExtras.find(instance->id());
+                if (iter != m_instanceExtras.end() && iter->second.window)
+                    parent = iter->second.window;
+            }
+
+            QMessageBox warning(parent);
+            warning.setWindowTitle(tr("Launch another Minecraft process?"));
+            warning.setIcon(QMessageBox::Warning);
+            warning.setText(tr("This instance is already running."));
+            warning.setInformativeText(
+                tr("Both Minecraft processes will use the same game folder and the same config, options, logs, and saves. "
+                   "Running them together can cause conflicting writes and data loss."));
+            auto* launchButton = warning.addButton(tr("Launch Anyway"), QMessageBox::AcceptRole);
+            warning.addButton(tr("Cancel"), QMessageBox::RejectRole);
+            QCheckBox dontShowAgain(tr("Don't show this warning again"), &warning);
+            warning.setCheckBox(&dontShowAgain);
+            warning.exec();
+            if (dontShowAgain.isChecked())
+                m_settings->set("SuppressConcurrentLaunchWarning", true);
+            if (warning.clickedButton() != launchButton)
+                return false;
+        }
+
         QMutexLocker locker(&m_instanceExtrasMutex);
         auto& extras = m_instanceExtras[instance->id()];
         auto window = extras.window;
@@ -1551,25 +1581,23 @@ bool Application::launch(BaseInstance* instance,
                 return false;
             }
         }
-        auto& controller = extras.controller;
-        controller.reset(new LaunchController());
-        controller->setInstance(instance);
-        controller->setLaunchMode(mode);
-        controller->setProfiler(profilers().value(instance->settings()->get("Profiler").toString(), nullptr).get());
-        controller->setTargetToJoin(targetToJoin);
-        controller->setAccountToUse(accountToUse);
-        controller->setOfflineName(offlineName);
+        auto controller = std::make_unique<LaunchController>();
+        auto* controllerPtr = controller.get();
+        controllerPtr->setInstance(instance);
+        controllerPtr->setLaunchMode(mode);
+        controllerPtr->setProfiler(profilers().value(instance->settings()->get("Profiler").toString(), nullptr).get());
+        controllerPtr->setTargetToJoin(targetToJoin);
+        controllerPtr->setAccountToUse(accountToUse);
+        controllerPtr->setOfflineName(offlineName);
         if (window) {
-            controller->setParentWidget(window);
+            controllerPtr->setParentWidget(window);
         } else if (m_mainWindow) {
-            controller->setParentWidget(m_mainWindow);
+            controllerPtr->setParentWidget(m_mainWindow);
         }
-        connect(controller.get(), &LaunchController::finished, this, &Application::controllerFinished);
+        connect(controllerPtr, &LaunchController::finished, this, &Application::controllerFinished);
+        extras.controllers.emplace_back(std::move(controller));
         addRunningInstance();
-        QMetaObject::invokeMethod(controller.get(), &Task::start, Qt::QueuedConnection);
-        return true;
-    } else if (instance->isRunning()) {
-        showInstanceWindow(instance, "console");
+        QMetaObject::invokeMethod(controllerPtr, &Task::start, Qt::QueuedConnection);
         return true;
     } else if (instance->canEdit()) {
         showInstanceWindow(instance);
@@ -1578,7 +1606,7 @@ bool Application::launch(BaseInstance* instance,
     return false;
 }
 
-bool Application::kill(BaseInstance* instance)
+bool Application::kill(BaseInstance* instance, LaunchTask* session)
 {
     if (!instance->isRunning()) {
         qWarning() << "Attempted to kill instance" << instance->id() << ", which isn't running.";
@@ -1586,13 +1614,24 @@ bool Application::kill(BaseInstance* instance)
     }
     QMutexLocker locker(&m_instanceExtrasMutex);
     auto& extras = m_instanceExtras[instance->id()];
-    // NOTE: copy of the shared pointer keeps it alive
-    auto& controller = extras.controller;
-    locker.unlock();
-    if (controller) {
-        return controller->abort();
+    if (!session) {
+        const auto sessions = instance->launchTasks();
+        if (sessions.size() != 1) {
+            locker.unlock();
+            showInstanceWindow(instance, "console");
+            return false;
+        }
+        session = sessions.first();
     }
-    return true;
+
+    auto controller = std::find_if(extras.controllers.begin(), extras.controllers.end(),
+                                   [session](const auto& candidate) { return candidate->launcher() == session; });
+    auto* controllerPtr = controller == extras.controllers.end() ? nullptr : controller->get();
+    locker.unlock();
+    if (controllerPtr) {
+        return controllerPtr->abort();
+    }
+    return false;
 }
 
 void Application::closeCurrentWindow()
@@ -1641,26 +1680,33 @@ void Application::controllerFinished()
     auto controller = qobject_cast<LaunchController*>(sender());
     if (!controller)
         return;
-    auto id = controller->id();
-
-    QMutexLocker locker(&m_instanceExtrasMutex);
-    auto& extras = m_instanceExtras.at(id);
-
     const bool wasSuccessful = controller->wasSuccessful();
-    // on success, do...
-    if (wasSuccessful && controller->instance()->settings()->get("AutoCloseConsole").toBool()) {
-        if (extras.window) {
-            QMetaObject::invokeMethod(extras.window, &QWidget::close, Qt::QueuedConnection);
-        }
-    }
-    extras.controller.reset();
-    subRunningInstance();
+    const auto id = controller->id();
+    auto* instance = controller->instance();
 
-    // quit when there are no more windows.
-    if (shouldExitNow()) {
-        m_status = wasSuccessful ? Succeeded : Failed;
-        exit(wasSuccessful ? 0 : 1);
-    }
+    QMetaObject::invokeMethod(
+        this,
+        [this, controller, instance, id, wasSuccessful] {
+            QMutexLocker locker(&m_instanceExtrasMutex);
+            auto& extras = m_instanceExtras.at(id);
+            const auto iter = std::find_if(extras.controllers.begin(), extras.controllers.end(),
+                                           [controller](const auto& candidate) { return candidate.get() == controller; });
+            if (iter == extras.controllers.end())
+                return;
+
+            extras.controllers.erase(iter);
+            subRunningInstance();
+            if (wasSuccessful && !instance->isRunning() && instance->settings()->get("AutoCloseConsole").toBool() && extras.window) {
+                QMetaObject::invokeMethod(extras.window, &QWidget::close, Qt::QueuedConnection);
+            }
+            locker.unlock();
+
+            if (shouldExitNow()) {
+                m_status = wasSuccessful ? Succeeded : Failed;
+                exit(wasSuccessful ? 0 : 1);
+            }
+        },
+        Qt::QueuedConnection);
 }
 
 void Application::ShowGlobalSettings(class QWidget* parent, QString open_page)
@@ -1748,8 +1794,8 @@ InstanceWindow* Application::showInstanceWindow(BaseInstance* instance, QString 
     if (!page.isEmpty()) {
         window->selectPage(page);
     }
-    if (extras.controller) {
-        extras.controller->setParentWidget(window);
+    for (const auto& controller : extras.controllers) {
+        controller->setParentWidget(window);
     }
     return window;
 }
@@ -1762,8 +1808,8 @@ void Application::on_windowClose()
         QMutexLocker locker(&m_instanceExtrasMutex);
         auto& extras = m_instanceExtras[instWindow->instanceId()];
         extras.window = nullptr;
-        if (extras.controller) {
-            extras.controller->setParentWidget(m_mainWindow);
+        for (const auto& controller : extras.controllers) {
+            controller->setParentWidget(m_mainWindow);
         }
     }
     auto mainWindow = qobject_cast<MainWindow*>(sender());

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -38,6 +38,7 @@
 #pragma once
 
 #include <memory>
+#include <list>
 
 #include <QApplication>
 #include <QDateTime>
@@ -53,6 +54,7 @@
 
 class PineconeNetworkCheck;
 class LaunchController;
+class LaunchTask;
 class LocalPeer;
 class InstanceWindow;
 class MainWindow;
@@ -223,7 +225,7 @@ class Application : public QApplication {
                 std::shared_ptr<MinecraftTarget> targetToJoin = nullptr,
                 shared_qobject_ptr<MinecraftAccount> accountToUse = nullptr,
                 const QString& offlineName = QString());
-    bool kill(BaseInstance* instance);
+    bool kill(BaseInstance* instance, LaunchTask* session = nullptr);
     void closeCurrentWindow();
 
    private slots:
@@ -285,7 +287,7 @@ class Application : public QApplication {
     // FIXME: attach to instances instead.
     struct InstanceXtras {
         InstanceWindow* window = nullptr;
-        std::unique_ptr<LaunchController> controller;
+        std::list<std::unique_ptr<LaunchController>> controllers;
     };
     std::map<QString, InstanceXtras> m_instanceExtras;
     mutable QMutex m_instanceExtrasMutex;

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -42,6 +42,7 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <algorithm>
 
 #include "Application.h"
 #include "Json.h"
@@ -271,34 +272,77 @@ QString BaseInstance::id() const
 
 bool BaseInstance::isRunning() const
 {
-    return m_isRunning;
+    return !m_activeLaunchProcesses.isEmpty();
 }
 
-void BaseInstance::setRunning(bool running)
+void BaseInstance::launchSessionStarted(LaunchTask* task)
 {
-    if (running == m_isRunning)
+    if (!task || m_activeLaunchProcesses.contains(task))
         return;
 
-    m_isRunning = running;
-
-    emit runningStatusChanged(running);
+    const bool wasRunning = isRunning();
+    if (!wasRunning) {
+        m_launchIntervalCrashed = false;
+        setCrashed(false);
+    }
+    m_activeLaunchProcesses.insert(task);
+    if (!wasRunning) {
+        emit runningStatusChanged(true);
+    }
 }
 
-void BaseInstance::setMinecraftRunning(bool running)
+void BaseInstance::launchSessionFinished(LaunchTask* task, bool crashed)
 {
-    if (!settings()->get("RecordGameTime").toBool()) {
+    if (!task || !m_activeLaunchProcesses.remove(task))
         return;
+
+    setMinecraftRunning(task, false);
+    m_launchIntervalCrashed |= crashed;
+    if (!isRunning()) {
+        setCrashed(m_launchIntervalCrashed);
+        emit runningStatusChanged(false);
     }
 
-    if (running) {
-        m_timeStarted = QDateTime::currentDateTime();
-        setLastLaunch(m_timeStarted.toMSecsSinceEpoch());
-    } else {
-        QDateTime timeEnded = QDateTime::currentDateTime();
+    const auto sessionId = task->sessionId();
+    QMetaObject::invokeMethod(
+        this,
+        [this, task, sessionId] {
+            const auto iter = std::find_if(m_launchProcesses.begin(), m_launchProcesses.end(),
+                                           [task](const auto& candidate) { return candidate.get() == task; });
+            if (iter == m_launchProcesses.end())
+                return;
+            emit launchTaskRemoved(sessionId);
+            m_launchProcesses.erase(iter);
+        },
+        Qt::QueuedConnection);
+}
 
+void BaseInstance::setMinecraftRunning(LaunchTask* task, bool running)
+{
+    if (!task)
+        return;
+
+    if (running) {
+        if (m_minecraftProcesses.contains(task))
+            return;
+
+        const auto now = QDateTime::currentDateTime();
+        setLastLaunch(now.toMSecsSinceEpoch());
+        if (m_minecraftProcesses.isEmpty() && settings()->get("RecordGameTime").toBool()) {
+            m_timeStarted = now;
+        }
+        m_minecraftProcesses.insert(task);
+    } else {
+        if (!m_minecraftProcesses.remove(task))
+            return;
+        if (!m_minecraftProcesses.isEmpty() || !settings()->get("RecordGameTime").toBool())
+            return;
+
+        const auto timeEnded = QDateTime::currentDateTime();
+        const auto elapsed = m_timeStarted.secsTo(timeEnded);
         qint64 current = settings()->get("totalTimePlayed").toLongLong();
-        settings()->set("totalTimePlayed", current + m_timeStarted.secsTo(timeEnded));
-        settings()->set("lastTimePlayed", m_timeStarted.secsTo(timeEnded));
+        settings()->set("totalTimePlayed", current + elapsed);
+        settings()->set("lastTimePlayed", elapsed);
 
         emit propertiesChanged(this);
     }
@@ -307,7 +351,7 @@ void BaseInstance::setMinecraftRunning(bool running)
 int64_t BaseInstance::totalTimePlayed() const
 {
     qint64 current = m_settings->get("totalTimePlayed").toLongLong();
-    if (m_isRunning) {
+    if (!m_minecraftProcesses.isEmpty() && m_timeStarted.isValid() && m_settings->get("RecordGameTime").toBool()) {
         QDateTime timeNow = QDateTime::currentDateTime();
         return current + m_timeStarted.secsTo(timeNow);
     }
@@ -316,7 +360,7 @@ int64_t BaseInstance::totalTimePlayed() const
 
 int64_t BaseInstance::lastTimePlayed() const
 {
-    if (m_isRunning) {
+    if (!m_minecraftProcesses.isEmpty() && m_timeStarted.isValid() && m_settings->get("RecordGameTime").toBool()) {
         QDateTime timeNow = QDateTime::currentDateTime();
         return m_timeStarted.secsTo(timeNow);
     }
@@ -348,7 +392,7 @@ SettingsObject* BaseInstance::settings()
 
 bool BaseInstance::canLaunch() const
 {
-    return (!hasVersionBroken() && !isRunning());
+    return !hasVersionBroken();
 }
 
 bool BaseInstance::reloadSettings()
@@ -471,9 +515,34 @@ QStringList BaseInstance::extraArguments()
     return Commandline::splitArgs(settings()->get("JvmArgs").toString());
 }
 
-LaunchTask* BaseInstance::getLaunchTask()
+QList<LaunchTask*> BaseInstance::launchTasks() const
 {
-    return m_launchProcess.get();
+    QList<LaunchTask*> result;
+    result.reserve(static_cast<qsizetype>(m_launchProcesses.size()));
+    for (const auto& task : m_launchProcesses) {
+        result.append(task.get());
+    }
+    return result;
+}
+
+LaunchTask* BaseInstance::launchTask(quint64 sessionId) const
+{
+    const auto iter = std::find_if(m_launchProcesses.begin(), m_launchProcesses.end(),
+                                   [sessionId](const auto& task) { return task->sessionId() == sessionId; });
+    return iter == m_launchProcesses.end() ? nullptr : iter->get();
+}
+
+LaunchTask* BaseInstance::adoptLaunchTask(std::unique_ptr<LaunchTask> task)
+{
+    if (!task)
+        return nullptr;
+
+    auto* result = task.get();
+    result->setSessionId(m_nextLaunchSessionId++);
+    m_launchProcesses.emplace_back(std::move(task));
+    result->init();
+    emit launchTaskAdded(result);
+    return result;
 }
 
 void BaseInstance::updateRuntimeContext()

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -45,6 +45,7 @@
 #include <QObject>
 #include <QProcess>
 #include <QSet>
+#include <list>
 #include "QObjectPtr.h"
 
 #include "settings/SettingsObject.h"
@@ -116,8 +117,7 @@ class BaseInstance : public QObject {
     /// be unique.
     virtual QString id() const;
 
-    void setMinecraftRunning(bool running);
-    void setRunning(bool running);
+    void setMinecraftRunning(LaunchTask* task, bool running);
     bool isRunning() const;
     int64_t totalTimePlayed() const;
     int64_t lastTimePlayed() const;
@@ -203,8 +203,12 @@ class BaseInstance : public QObject {
     /// returns a valid launcher (task container)
     virtual LaunchTask* createLaunchTask(AuthSessionPtr account, MinecraftTarget::Ptr targetToJoin) = 0;
 
-    /// returns the current launch task (if any)
-    LaunchTask* getLaunchTask();
+    /// Returns all active launch sessions, in creation order.
+    QList<LaunchTask*> launchTasks() const;
+    LaunchTask* launchTask(quint64 sessionId) const;
+    LaunchTask* adoptLaunchTask(std::unique_ptr<LaunchTask> task);
+    void launchSessionStarted(LaunchTask* task);
+    void launchSessionFinished(LaunchTask* task, bool crashed);
 
     /*!
      * Create envrironment variables for running the instance
@@ -294,7 +298,8 @@ class BaseInstance : public QObject {
      */
     void propertiesChanged(BaseInstance* inst);
 
-    void launchTaskChanged(LaunchTask*);
+    void launchTaskAdded(LaunchTask*);
+    void launchTaskRemoved(quint64 sessionId);
 
     void runningStatusChanged(bool running);
 
@@ -309,8 +314,11 @@ class BaseInstance : public QObject {
     QString m_rootDir;
     std::unique_ptr<SettingsObject> m_settings;
     // InstanceFlags m_flags;
-    bool m_isRunning = false;
-    std::unique_ptr<LaunchTask> m_launchProcess;
+    std::list<std::unique_ptr<LaunchTask>> m_launchProcesses;
+    QSet<LaunchTask*> m_activeLaunchProcesses;
+    QSet<LaunchTask*> m_minecraftProcesses;
+    quint64 m_nextLaunchSessionId = 1;
+    bool m_launchIntervalCrashed = false;
     QDateTime m_timeStarted;
     RuntimeContext m_runtimeContext;
 

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -64,6 +64,11 @@
 
 LaunchController::LaunchController() = default;
 
+LaunchTask* LaunchController::launcher() const
+{
+    return m_launcher.data();
+}
+
 void LaunchController::executeTask()
 {
     if (!m_instance) {
@@ -397,6 +402,7 @@ void LaunchController::launchInstance()
     connect(m_launcher, &LaunchTask::readyForLaunch, this, &LaunchController::readyForLaunch);
     connect(m_launcher, &LaunchTask::succeeded, this, &LaunchController::onSucceeded);
     connect(m_launcher, &LaunchTask::failed, this, &LaunchController::onFailed);
+    connect(m_launcher, &LaunchTask::aborted, this, [this] { emitAborted(); });
     connect(m_launcher, &LaunchTask::requestProgress, this, &LaunchController::onProgressRequested);
 
     // Prepend Online and Auth Status

--- a/launcher/LaunchController.h
+++ b/launcher/LaunchController.h
@@ -35,6 +35,7 @@
 
 #pragma once
 #include <BaseInstance.h>
+#include <QPointer>
 #include <tools/BaseProfiler.h>
 
 #include "minecraft/auth/MinecraftAccount.h"
@@ -69,6 +70,7 @@ class LaunchController : public Task {
     void setAccountToUse(MinecraftAccountPtr accountToUse) { m_accountToUse = std::move(accountToUse); }
 
     QString id() const { return m_instance->id(); }
+    LaunchTask* launcher() const;
 
     bool abort() override;
 
@@ -98,6 +100,6 @@ class LaunchController : public Task {
     InstanceWindow* m_console = nullptr;
     MinecraftAccountPtr m_accountToUse = nullptr;
     AuthSessionPtr m_session = nullptr;
-    LaunchTask* m_launcher = nullptr;
+    QPointer<LaunchTask> m_launcher;
     MinecraftTarget::Ptr m_targetToJoin = nullptr;
 };

--- a/launcher/launch/LaunchTask.cpp
+++ b/launcher/launch/LaunchTask.cpp
@@ -48,14 +48,12 @@
 
 void LaunchTask::init()
 {
-    m_instance->setRunning(true);
+    m_instance->launchSessionStarted(this);
 }
 
 std::unique_ptr<LaunchTask> LaunchTask::create(MinecraftInstance* inst)
 {
-    auto task = std::unique_ptr<LaunchTask>(new LaunchTask(inst));
-    task->init();
-    return task;
+    return std::unique_ptr<LaunchTask>(new LaunchTask(inst));
 }
 
 LaunchTask::LaunchTask(MinecraftInstance* instance) : m_instance(instance) {}
@@ -72,7 +70,6 @@ void LaunchTask::prependStep(shared_qobject_ptr<LaunchStep> step)
 
 void LaunchTask::executeTask()
 {
-    m_instance->setCrashed(false);
     if (!m_steps.size()) {
         state = LaunchTask::Finished;
         emitSucceeded();
@@ -290,15 +287,23 @@ void LaunchTask::onLogLine(QString line, MessageLevel level)
 
 void LaunchTask::emitSucceeded()
 {
-    m_instance->setRunning(false);
+    state = LaunchTask::Finished;
+    m_instance->launchSessionFinished(this, false);
     Task::emitSucceeded();
 }
 
 void LaunchTask::emitFailed(QString reason)
 {
-    m_instance->setRunning(false);
-    m_instance->setCrashed(true);
+    state = LaunchTask::Failed;
+    m_instance->launchSessionFinished(this, true);
     Task::emitFailed(reason);
+}
+
+void LaunchTask::emitAborted()
+{
+    state = LaunchTask::Aborted;
+    m_instance->launchSessionFinished(this, false);
+    Task::emitAborted();
 }
 
 QString expandVariables(const QString& input, QProcessEnvironment dict)

--- a/launcher/launch/LaunchTask.h
+++ b/launcher/launch/LaunchTask.h
@@ -46,6 +46,7 @@
 
 class LaunchTask : public Task {
     Q_OBJECT
+    friend class BaseInstance;
    protected:
     explicit LaunchTask(MinecraftInstance* instance);
     void init();
@@ -66,6 +67,7 @@ class LaunchTask : public Task {
     void setPid(qint64 pid) { m_pid = pid; }
 
     qint64 pid() { return m_pid; }
+    quint64 sessionId() const { return m_sessionId; }
 
     /**
      * @brief prepare the process for launch (for multi-stage launch)
@@ -93,6 +95,7 @@ class LaunchTask : public Task {
    protected: /* methods */
     virtual void emitFailed(QString reason) override;
     virtual void emitSucceeded() override;
+    virtual void emitAborted() override;
 
    signals:
     /**
@@ -113,6 +116,7 @@ class LaunchTask : public Task {
 
    private: /*methods */
     void finalizeSteps(bool successful, const QString& error);
+    void setSessionId(quint64 sessionId) { m_sessionId = sessionId; }
 
    protected:
     bool parseXmlLogs(QString const& line, MessageLevel level);
@@ -125,6 +129,7 @@ class LaunchTask : public Task {
     int currentStep = -1;
     State state = NotStarted;
     qint64 m_pid = -1;
+    quint64 m_sessionId = 0;
     LogParser m_stdoutParser;
     LogParser m_stderrParser;
 };

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1261,9 +1261,7 @@ LaunchTask* MinecraftInstance::createLaunchTask(AuthSessionPtr session, Minecraf
     if (m_settings->get("QuitAfterGameStop").toBool()) {
         process->appendStep(makeShared<QuitAfterGameStop>(pptr));
     }
-    m_launchProcess = std::move(process);
-    emit launchTaskChanged(m_launchProcess.get());
-    return m_launchProcess.get();
+    return adoptLaunchTask(std::move(process));
 }
 
 JavaVersion MinecraftInstance::getJavaVersion()

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -172,7 +172,7 @@ void LauncherPartLaunch::on_state(LoggedProcess::State state)
         case LoggedProcess::Aborted:
         case LoggedProcess::Crashed: {
             m_parent->setPid(-1);
-            m_parent->instance()->setMinecraftRunning(false);
+            m_parent->instance()->setMinecraftRunning(m_parent, false);
             emitFailed(tr("Game crashed."));
             return;
         }
@@ -182,7 +182,7 @@ void LauncherPartLaunch::on_state(LoggedProcess::State state)
                 APPLICATION->showMainWindow();
 
             m_parent->setPid(-1);
-            m_parent->instance()->setMinecraftRunning(false);
+            m_parent->instance()->setMinecraftRunning(m_parent, false);
             // if the exit code wasn't 0, report this as a crash
             auto exitCode = m_process.exitCode();
             if (exitCode != 0) {
@@ -217,7 +217,7 @@ void LauncherPartLaunch::setWorkingDirectory(const QString& wd)
 void LauncherPartLaunch::proceed()
 {
     if (mayProceed) {
-        m_parent->instance()->setMinecraftRunning(true);
+        m_parent->instance()->setMinecraftRunning(m_parent, true);
         QString launchString("launch\n");
         m_process.write(launchString.toUtf8());
         mayProceed = false;

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -46,6 +46,7 @@
 #include "ui/widgets/PageContainer.h"
 
 #include "InstancePageProvider.h"
+#include "ui/pages/instance/LogPage.h"
 
 #include "icons/IconList.h"
 
@@ -98,7 +99,7 @@ InstanceWindow::InstanceWindow(BaseInstance* instance, QWidget* parent) : QMainW
         m_killButton->setToolTip(tr("Kill the running instance"));
         m_killButton->setShortcut(QKeySequence(tr("Ctrl+K")));
         horizontalLayout->addWidget(m_killButton);
-        connect(m_killButton, &QPushButton::clicked, this, [this] { APPLICATION->kill(m_instance); });
+        connect(m_killButton, &QPushButton::clicked, this, [this] { APPLICATION->kill(m_instance, m_proc); });
 
         updateButtons();
 
@@ -123,10 +124,15 @@ InstanceWindow::InstanceWindow(BaseInstance* instance, QWidget* parent) : QMainW
 
     // set up instance and launch process recognition
     {
-        auto launchTask = m_instance->getLaunchTask();
-        instanceLaunchTaskChanged(launchTask);
-        connect(m_instance, &BaseInstance::launchTaskChanged, this, &InstanceWindow::instanceLaunchTaskChanged);
+        const auto launchTasks = m_instance->launchTasks();
+        if (!launchTasks.isEmpty())
+            m_proc = launchTasks.last();
+        connect(m_instance, &BaseInstance::launchTaskAdded, this, &InstanceWindow::instanceLaunchTaskAdded);
+        connect(m_instance, &BaseInstance::launchTaskRemoved, this, &InstanceWindow::instanceLaunchTaskRemoved);
         connect(m_instance, &BaseInstance::runningStatusChanged, this, &InstanceWindow::runningStateChanged);
+        auto* logPage = dynamic_cast<LogPage*>(m_container->getPage("console"));
+        if (logPage)
+            connect(logPage, &LogPage::selectedLaunchTaskChanged, this, &InstanceWindow::selectedLaunchTaskChanged);
     }
 
     // set up instance destruction detection
@@ -153,7 +159,7 @@ void InstanceWindow::on_instanceStatusChanged(BaseInstance::Status, BaseInstance
 void InstanceWindow::updateButtons()
 {
     m_launchButton->setEnabled(m_instance->canLaunch());
-    m_killButton->setEnabled(m_instance->isRunning());
+    m_killButton->setEnabled(m_proc && m_instance->isRunning());
 
     QMenu* launchMenu = m_launchButton->menu();
     if (launchMenu)
@@ -164,9 +170,30 @@ void InstanceWindow::updateButtons()
     m_launchButton->setMenu(launchMenu);
 }
 
-void InstanceWindow::instanceLaunchTaskChanged(LaunchTask* proc)
+void InstanceWindow::instanceLaunchTaskAdded(LaunchTask* proc)
 {
     m_proc = proc;
+    updateButtons();
+    selectPage("console");
+}
+
+void InstanceWindow::instanceLaunchTaskRemoved(quint64 sessionId)
+{
+    if (m_proc && m_proc->sessionId() == sessionId) {
+        const auto tasks = m_instance->launchTasks();
+        m_proc = nullptr;
+        for (auto* task : tasks) {
+            if (task->sessionId() != sessionId)
+                m_proc = task;
+        }
+    }
+    updateButtons();
+}
+
+void InstanceWindow::selectedLaunchTaskChanged(LaunchTask* proc)
+{
+    m_proc = proc;
+    updateButtons();
 }
 
 void InstanceWindow::runningStateChanged(bool running)
@@ -174,7 +201,7 @@ void InstanceWindow::runningStateChanged(bool running)
     updateButtons();
     m_container->refreshContainer();
     if (running) {
-        selectPage("log");
+        selectPage("console");
     }
 }
 

--- a/launcher/ui/InstanceWindow.h
+++ b/launcher/ui/InstanceWindow.h
@@ -72,7 +72,9 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     void isClosing();
 
    private slots:
-    void instanceLaunchTaskChanged(LaunchTask* proc);
+    void instanceLaunchTaskAdded(LaunchTask* proc);
+    void instanceLaunchTaskRemoved(quint64 sessionId);
+    void selectedLaunchTaskChanged(LaunchTask* proc);
     void runningStateChanged(bool running);
     void on_instanceStatusChanged(BaseInstance::Status, BaseInstance::Status newStatus);
 
@@ -83,7 +85,7 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     void updateButtons();
 
    private:
-    LaunchTask* m_proc;
+    LaunchTask* m_proc = nullptr;
     BaseInstance* m_instance;
     bool m_doNotSave = false;
     PageContainer* m_container = nullptr;

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1612,7 +1612,7 @@ void MainWindow::instanceActivated(QModelIndex index)
 
 void MainWindow::on_actionLaunchInstance_triggered()
 {
-    if (m_selectedInstance && !m_selectedInstance->isRunning()) {
+    if (m_selectedInstance) {
         APPLICATION->launch(m_selectedInstance);
     }
 }
@@ -1784,6 +1784,20 @@ void MainWindow::setInstanceActionsEnabled(bool enabled)
 
 void MainWindow::refreshCurrentInstance()
 {
-    auto current = view->selectionModel()->currentIndex();
-    instanceChanged(current, current);
+    if (!m_selectedInstance)
+        return;
+
+    // Running state changes can cause the sorted instance model to move the
+    // selected row. Do not re-resolve the selection through a transient model
+    // index here: an invalid index would disable the whole instance toolbar.
+    ui->instanceToolBar->setEnabled(true);
+    setInstanceActionsEnabled(true);
+    ui->actionLaunchInstance->setEnabled(m_selectedInstance->canLaunch());
+    ui->actionKillInstance->setEnabled(m_selectedInstance->isRunning());
+    ui->actionExportInstance->setEnabled(m_selectedInstance->canExport());
+    renameButton->setText(m_selectedInstance->name());
+    m_statusLeft->setText(m_selectedInstance->getStatusbarDescription());
+    updateStatusCenter();
+    updateInstanceToolIcon(m_selectedInstance->iconKey());
+    updateLaunchButton();
 }

--- a/launcher/ui/pages/instance/LogPage.cpp
+++ b/launcher/ui/pages/instance/LogPage.cpp
@@ -149,11 +149,18 @@ LogPage::LogPage(BaseInstance* instance, QWidget* parent) : QWidget(parent), ui(
 
     // set up instance and launch process recognition
     {
-        auto launchTask = m_instance->getLaunchTask();
-        if (launchTask) {
-            setInstanceLaunchTaskChanged(launchTask, true);
+        const auto tasks = m_instance->launchTasks();
+        for (auto* task : tasks) {
+            ui->sessionCombo->addItem(tr("Minecraft #%1").arg(task->sessionId()), QVariant::fromValue<qulonglong>(task->sessionId()));
         }
-        connect(m_instance, &BaseInstance::launchTaskChanged, this, &LogPage::onInstanceLaunchTaskChanged);
+        if (!tasks.isEmpty()) {
+            ui->sessionCombo->setCurrentIndex(tasks.size() - 1);
+            setInstanceLaunchTaskChanged(tasks.last(), true);
+        }
+        ui->sessionLabel->setVisible(!tasks.isEmpty());
+        ui->sessionCombo->setVisible(!tasks.isEmpty());
+        connect(m_instance, &BaseInstance::launchTaskAdded, this, &LogPage::onInstanceLaunchTaskAdded);
+        connect(m_instance, &BaseInstance::launchTaskRemoved, this, &LogPage::onInstanceLaunchTaskRemoved);
     }
 
     auto findShortcut = new QShortcut(QKeySequence(QKeySequence::Find), this);
@@ -220,9 +227,43 @@ void LogPage::setInstanceLaunchTaskChanged(LaunchTask* proc, bool initial)
     }
 }
 
-void LogPage::onInstanceLaunchTaskChanged(LaunchTask* proc)
+int LogPage::sessionIndex(quint64 sessionId) const
 {
-    setInstanceLaunchTaskChanged(proc, false);
+    for (int index = 0; index < ui->sessionCombo->count(); ++index) {
+        if (ui->sessionCombo->itemData(index).toULongLong() == sessionId)
+            return index;
+    }
+    return -1;
+}
+
+void LogPage::on_sessionCombo_currentIndexChanged(int index)
+{
+    auto* task = index < 0 ? nullptr : m_instance->launchTask(ui->sessionCombo->itemData(index).toULongLong());
+    if (task != m_process)
+        setInstanceLaunchTaskChanged(task, false);
+    emit selectedLaunchTaskChanged(task);
+}
+
+void LogPage::onInstanceLaunchTaskAdded(LaunchTask* proc)
+{
+    ui->sessionCombo->addItem(tr("Minecraft #%1").arg(proc->sessionId()), QVariant::fromValue<qulonglong>(proc->sessionId()));
+    ui->sessionLabel->show();
+    ui->sessionCombo->show();
+    ui->sessionCombo->setCurrentIndex(ui->sessionCombo->count() - 1);
+}
+
+void LogPage::onInstanceLaunchTaskRemoved(quint64 sessionId)
+{
+    const int index = sessionIndex(sessionId);
+    if (index >= 0)
+        ui->sessionCombo->removeItem(index);
+    const bool hasSessions = ui->sessionCombo->count() > 0;
+    ui->sessionLabel->setVisible(hasSessions);
+    ui->sessionCombo->setVisible(hasSessions);
+    if (!hasSessions) {
+        setInstanceLaunchTaskChanged(nullptr, false);
+        emit selectedLaunchTaskChanged(nullptr);
+    }
 }
 
 bool LogPage::apply()

--- a/launcher/ui/pages/instance/LogPage.h
+++ b/launcher/ui/pages/instance/LogPage.h
@@ -73,6 +73,9 @@ class LogPage : public QWidget, public BasePage {
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 
+   signals:
+    void selectedLaunchTaskChanged(LaunchTask* task);
+
    private slots:
     void on_btnPaste_clicked();
     void on_btnCopy_clicked();
@@ -88,17 +91,20 @@ class LogPage : public QWidget, public BasePage {
     void findNextActivated();
     void findPreviousActivated();
 
-    void onInstanceLaunchTaskChanged(LaunchTask* proc);
+    void on_sessionCombo_currentIndexChanged(int index);
+    void onInstanceLaunchTaskAdded(LaunchTask* proc);
+    void onInstanceLaunchTaskRemoved(quint64 sessionId);
 
    private:
     void modelStateToUI();
     void UIToModelState();
     void setInstanceLaunchTaskChanged(LaunchTask* proc, bool initial);
+    int sessionIndex(quint64 sessionId) const;
 
    private:
     Ui::LogPage* ui;
     BaseInstance* m_instance;
-    LaunchTask* m_process;
+    LaunchTask* m_process = nullptr;
 
     LogFormatProxyModel* m_proxy;
     shared_qobject_ptr<LogModel> m_model;

--- a/launcher/ui/pages/instance/LogPage.ui
+++ b/launcher/ui/pages/instance/LogPage.ui
@@ -42,6 +42,20 @@
    <item row="0" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QLabel" name="sessionLabel">
+       <property name="text">
+        <string>Process:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="sessionCombo">
+       <property name="minimumContentsLength">
+        <number>14</number>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QCheckBox" name="trackLogCheckbox">
        <property name="text">
         <string>Keep updating</string>
@@ -168,7 +182,8 @@
    <header>ui/widgets/LogView.h</header>
   </customwidget>
  </customwidgets>
- <tabstops>
+  <tabstops>
+   <tabstop>sessionCombo</tabstop>
   <tabstop>trackLogCheckbox</tabstop>
   <tabstop>wrapCheckbox</tabstop>
   <tabstop>colorCheckbox</tabstop>

--- a/tests/BaseInstance_test.cpp
+++ b/tests/BaseInstance_test.cpp
@@ -1,0 +1,119 @@
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QTest>
+
+#include <tasks/Task.h>
+#include <BaseInstance.h>
+#include <launch/LaunchTask.h>
+#include <settings/INISettingsObject.h>
+
+class TestLaunchTask final : public LaunchTask {
+   public:
+    TestLaunchTask() : LaunchTask(nullptr) {}
+};
+
+class TestInstance final : public BaseInstance {
+   public:
+    TestInstance(SettingsObject* globalSettings, std::unique_ptr<SettingsObject> settings, const QString& rootDir)
+        : BaseInstance(globalSettings, std::move(settings), rootDir)
+    {}
+
+    void saveNow() override {}
+    QString modsRoot() const override { return instanceRoot(); }
+    QSet<QString> traits() const override { return {}; }
+    void loadSpecificSettings() override { setSpecificSettingsLoaded(true); }
+    QList<Task::Ptr> createUpdateTask() override { return {}; }
+    LaunchTask* createLaunchTask(AuthSessionPtr, MinecraftTarget::Ptr) override { return nullptr; }
+    QProcessEnvironment createEnvironment() override { return {}; }
+    QProcessEnvironment createLaunchEnvironment() override { return {}; }
+    QStringList getLogFileSearchPaths() override { return {}; }
+    QString getStatusbarDescription() override { return {}; }
+    QString instanceConfigFolder() const override { return instanceRoot(); }
+    QMap<QString, QString> getVariables() override { return {}; }
+    QString typeName() const override { return QStringLiteral("Test"); }
+    bool canEdit() const override { return true; }
+    bool canExport() const override { return true; }
+    void populateLaunchMenu(QMenu*) override {}
+    QStringList verboseDescription(AuthSessionPtr, MinecraftTarget::Ptr) override { return {}; }
+};
+
+class BaseInstanceTest : public QObject {
+    Q_OBJECT
+
+   private:
+    static std::unique_ptr<INISettingsObject> createGlobalSettings(const QString& path)
+    {
+        auto settings = std::make_unique<INISettingsObject>(path);
+        settings->registerSetting("ShowGameTime", true);
+        settings->registerSetting("RecordGameTime", true);
+        settings->registerSetting("PreLaunchCommand", "");
+        settings->registerSetting("WrapperCommand", "");
+        settings->registerSetting("PostExitCommand", "");
+        settings->registerSetting("ShowConsole", false);
+        settings->registerSetting("AutoCloseConsole", false);
+        settings->registerSetting("ShowConsoleOnError", true);
+        settings->registerSetting("LogPrePostOutput", true);
+        settings->registerSetting("ConsoleMaxLines", 1000);
+        settings->registerSetting("ConsoleOverflowStop", true);
+        return settings;
+    }
+
+   private slots:
+    void aggregateRunningStateAndCanLaunch()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        auto global = createGlobalSettings(dir.filePath("global.cfg"));
+        auto local = std::make_unique<INISettingsObject>(dir.filePath("instance.cfg"));
+        TestInstance instance(global.get(), std::move(local), dir.path());
+        TestLaunchTask first;
+        TestLaunchTask second;
+        QSignalSpy runningChanges(&instance, &BaseInstance::runningStatusChanged);
+
+        QVERIFY(instance.canLaunch());
+        instance.launchSessionStarted(&first);
+        QVERIFY(instance.isRunning());
+        QVERIFY(instance.canLaunch());
+        QCOMPARE(runningChanges.count(), 1);
+        QCOMPARE(runningChanges.at(0).at(0).toBool(), true);
+
+        instance.launchSessionStarted(&second);
+        QVERIFY(instance.isRunning());
+        QCOMPARE(runningChanges.count(), 1);
+
+        instance.launchSessionFinished(&first, false);
+        QVERIFY(instance.isRunning());
+        QCOMPARE(runningChanges.count(), 1);
+
+        instance.launchSessionFinished(&second, false);
+        QVERIFY(!instance.isRunning());
+        QCOMPARE(runningChanges.count(), 2);
+        QCOMPARE(runningChanges.at(1).at(0).toBool(), false);
+    }
+
+    void parallelMinecraftProcessesCountWallClockTimeOnce()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        auto global = createGlobalSettings(dir.filePath("global.cfg"));
+        auto local = std::make_unique<INISettingsObject>(dir.filePath("instance.cfg"));
+        TestInstance instance(global.get(), std::move(local), dir.path());
+        TestLaunchTask first;
+        TestLaunchTask second;
+
+        instance.setMinecraftRunning(&first, true);
+        instance.setMinecraftRunning(&second, true);
+        QTest::qWait(1100);
+        instance.setMinecraftRunning(&first, false);
+        QVERIFY(instance.totalTimePlayed() <= 2);
+        instance.setMinecraftRunning(&second, false);
+
+        QVERIFY(instance.totalTimePlayed() >= 1);
+        QVERIFY(instance.totalTimePlayed() <= 2);
+        QCOMPARE(instance.lastTimePlayed(), instance.totalTimePlayed());
+    }
+};
+
+QTEST_GUILESS_MAIN(BaseInstanceTest)
+
+#include "BaseInstance_test.moc"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,9 @@ ecm_add_test(ParseUtils_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MA
 ecm_add_test(Task_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME Task)
 
+ecm_add_test(BaseInstance_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
+    TEST_NAME BaseInstance)
+
 ecm_add_test(INIFile_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME INIFile)
 


### PR DESCRIPTION
## Summary

- allow multiple independent launch sessions for the same instance and game directory
- keep per-session lifecycle, selectable logs, and targeted Kill behavior
- aggregate running/crash state and wall-clock play time across concurrent Minecraft processes
- warn before a concurrent launch, with a persistent opt-out setting
- keep Launch enabled while the selected instance is running
- document the feature and shared-directory risks in README

## Safety and lifetime

Launch tasks are owned by a move-only container. Completed sessions are removed on the event loop after completion signals have been delivered, avoiding callbacks into destroyed tasks. Aggregate running-state signals are emitted only for 0 -> 1 and 1 -> 0 transitions.

## Testing

- Windows MSVC Release target built successfully
- BaseInstance test passed (1/1)
- manually verified that Launch remains enabled while the selected instance is running

## DCO

The commit includes the required AI assistance attribution. Per CONTRIBUTING.md, the human submitter will add their own Signed-off-by certification after reviewing the contribution.